### PR TITLE
Fix grammar and spelling errors in text and figure captions

### DIFF
--- a/fig/stints.tex
+++ b/fig/stints.tex
@@ -10,7 +10,7 @@ To ensure genomes maintained viability as simulation seeds (e.g., for competitio
 Between stints, a whole-population snapshot of genome content was recorded and a sample genome was collected from the focal strain (``focal specimen'').
 To continue evolution in the following stint, a fresh simulation instance was initialized by shuffled injection of snapshot genomes.
 Note that, due to early extinctions, focal designation switched to a new strain at stint 2 in case study replicate, which was maintained onwards.
-A reosource-balancing diversity-maintenance procedure was used to curtail growth of any founder lineage beyond population majority, hence ensuring long-term coexistence of at least one independent ``background'' strain as ecological context.
+A resource-balancing diversity-maintenance procedure was used to curtail growth of any founder lineage beyond population majority, hence ensuring long-term coexistence of at least one independent ``background'' strain as ecological context.
 }
 \label{fig:stints}
 \end{figure}

--- a/tex/body/introduction.tex
+++ b/tex/body/introduction.tex
@@ -38,7 +38,7 @@ Indeed, among computer scientists, niche construction and Evolutionary Transitio
 The next section describes our experimental system, detailing how model digital organisms replicate, form multicells, and interact with other multicells.
 Following this, we examine complexity, novelty, and adaptation across the genomic and phenotypic history of a case study lineage exhibiting high genetic complexity, high phenotypic complexity, and morphological innovation.
 Further examining this high-complexity lineage, competition assays reveal it evolved to become fit when abundant --- in other words, when serving as its own environmental context.
-Using further competition assays, we next test whether this niche construction effect substantially drive selection on the high-complexity lineage.
+Using further competition assays, we next test whether this niche construction effect substantially drives selection on the high-complexity lineage.
 % unexpected that self-selection doesn't "freeze" evolution but that
 Lastly, we use replay experiments along the high-complexity lineage's history to test the causal role of niche construction in maintaining evolved complexity.
 

--- a/tex/body/results.tex
+++ b/tex/body/results.tex
@@ -154,7 +154,7 @@ At the end of each replay, we sampled a genotype from descendants of the mutagen
 
 Across replays, self context indeed preserved greater genetic complexity in the case study strain, compared to co-evolved ecological context
 (Mann-Whitney $U$ test, $p < 0.01$, $\delta = 0.25$; Figure \ref{fig:replay-background:moderatedose}).
-Importantly, this result provides direct evidence that biotic selection effects exerted by the case study strain acts to stabilize its own complexity.
+Importantly, this result provides direct evidence that biotic selection effects exerted by the case study strain act to stabilize its own complexity.
 
 To better understand the specificity of the case study strain in selecting for complexity, we repeated replay experiments with a higher dose of 50 mutations --- sufficient to ensure substantial disruption of all seeded case study genomes.
 % applied to seeded case study strain genotypes.


### PR DESCRIPTION
- Fix subject-verb agreement: "effect... drive" → "effect... drives" in introduction
- Fix spelling: "reosource-balancing" → "resource-balancing" in stints figure caption
- Fix subject-verb agreement: "effects... acts" → "effects... act" in results