### PR TITLE
Fix figure spacing issues

### DIFF
--- a/fig/fit-advantage-correlations.tex
+++ b/fig/fit-advantage-correlations.tex
@@ -24,6 +24,7 @@ All
 \includegraphics[align=t,width=0.39\linewidth,trim={0 0.7cm 0 0},clip]{binder-2025-12-10-complexty-fitness-correlation.ipynb/binder/teeplots/2025-12-10-complexty-fitness-correlation/viz=lmplot+when=early+x=genotype-complexity+y=focal-prevalence-difference+ext=.pdf}
 \includegraphics[align=t,width=0.295\linewidth,trim={1.45cm 0.7cm 0 0},clip]{binder-2025-12-10-complexty-fitness-correlation.ipynb/binder/teeplots/2025-12-10-complexty-fitness-correlation/viz=lmplot+when=late+x=genotype-complexity+y=focal-prevalence-difference+ext=.pdf}
 \includegraphics[align=t,width=0.295\linewidth,trim={1.45cm 0.7cm 0 0},clip]{binder-2025-12-10-complexty-fitness-correlation.ipynb/binder/teeplots/2025-12-10-complexty-fitness-correlation/viz=lmplot+when=all+x=genotype-complexity+y=focal-prevalence-difference+ext=.pdf}
+\vspace{-0.75em}
 \caption{\footnotesize
 genotype complexity
 }
@@ -38,6 +39,7 @@ genotype complexity
 \includegraphics[align=t,width=0.39\linewidth,trim={0 0.7cm 0 0},clip]{binder-2025-12-10-complexty-fitness-correlation.ipynb/binder/teeplots/2025-12-10-complexty-fitness-correlation/viz=lmplot+when=early+x=phenotype-complexity+y=focal-prevalence-difference+ext=.pdf}
 \includegraphics[align=t,width=0.295\linewidth,trim={1.45cm 0.7cm 0 0},clip]{binder-2025-12-10-complexty-fitness-correlation.ipynb/binder/teeplots/2025-12-10-complexty-fitness-correlation/viz=lmplot+when=late+x=phenotype-complexity+y=focal-prevalence-difference+ext=.pdf}
 \includegraphics[align=t,width=0.295\linewidth,trim={1.45cm 0.7cm 0 0},clip]{binder-2025-12-10-complexty-fitness-correlation.ipynb/binder/teeplots/2025-12-10-complexty-fitness-correlation/viz=lmplot+when=all+x=phenotype-complexity+y=focal-prevalence-difference+ext=.pdf}
+\vspace{-0.75em}
 \caption{\footnotesize
 phenotype complexity
 }

--- a/fig/fitness-background.tex
+++ b/fig/fitness-background.tex
@@ -1,14 +1,14 @@
 \begin{figure}
 
 \begin{minipage}{\linewidth}
-\begin{subfigure}{0.692\linewidth}
+\begin{subfigure}[b]{0.692\linewidth}
 \includegraphics[width=\linewidth, trim=0.8cm 0 0 0, clip]{binder-2025-11-30-external-selfbb-truebb.ipynb/binder/teeplots/2025-11-30-external-selfbb-truebb/hue=kind1+style=kind1+viz=lineplot+x=competition-stint+y=focal-prevalence+ext=.pdf}
 \footnotesize
 \vspace{-4.25ex}
 \caption{stints 0 to 100}
 \label{fig:fitness-background:timeseries}
 \end{subfigure}%
-\begin{subfigure}{0.308\linewidth}
+\begin{subfigure}[b]{0.308\linewidth}
 \includegraphics[width=\linewidth, trim=1.3cm 0 0 0.1cm, clip]{binder-2025-11-30-external-selfbb-truebb.ipynb/binder/teeplots/2025-11-30-external-selfbb-truebb/hue=kind+inner=quartile+viz=violinplot+x=kind+y=focal-prevalence+ext=.pdf}
 \footnotesize
 \vspace{-4.25ex}

--- a/fig/keyfig.tex
+++ b/fig/keyfig.tex
@@ -1,5 +1,6 @@
 \begin{figure*}
 \includegraphics[width=\linewidth]{binder-2025-08-24-keyfig/binder/teeplots/2025-08-24-keyfig/bbg=Without+traits=0+viz=subplots+ext=.pdf}
+\vspace{-1ex}
 \caption{%
 \textbf{Overview of complexity, novelty, and adaptation across evolutionary history of case study strain.}
 \footnotesize

--- a/fig/replay-background.tex
+++ b/fig/replay-background.tex
@@ -24,7 +24,7 @@ replay trial design
 \includegraphics[height=1.45in,trim=2.5cm 0 0 0,clip]{binder-2025-11-26-replaysmutagenized50.ipynb/binder/teeplots/2025-11-26-replaysmutagenized50/clip=62+hue=bucket+inner=quart+viz=violinplot+x=bucket+y=is-less-fit+ext=.pdf}
 \end{subfigure}
 
-\vspace{-2ex}
+\vspace{-1.5ex}
 \begin{subfigure}{0.25\linewidth}
 ~
 \end{subfigure}%


### PR DESCRIPTION
- Figure 4 (keyfig): Move caption up by 1ex
- Figure 6 (fitness-background): Bottom-align side-by-side subfigures
- Figure 8 (replay-background): Shift subcaption text down for (b) and (c)
- Figure 9 (fit-advantage-correlations): Tighten subcaption text on top by 0.75em

Fixes #48