### PR TITLE
Add ALIFE 2026 late-breaking abstract build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,10 @@ venv/
 
 oee4.pdf
 oee4-draft.pdf
+oee4-lba.pdf
 main.pdf
 main-draft.pdf
+main-lba.pdf
 
 ## Core latex/pdflatex auxiliary files:
 *.aux

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,13 @@ all: ${BUILD_DIR}-draft.pdf
 
 draft: ${BUILD_DIR}-draft.pdf ${BUILD_DIR}-manuscript-draft.pdf ${BUILD_DIR}-supplement-draft.pdf ${BUILD_DIR}-draft.tex
 
+lba: ${BUILD_DIR}-lba.pdf
+
+${BUILD_DIR}-lba.pdf: main-lba.tex bibl.bib tex/abstract.tex $(shell find tex/lba -type f) fig/overview.tex fig/fitness-background-lba.tex img/* lib/*
+	latexmk -pdf -silent \
+    -jobname=${BUILD_DIR}-lba \
+    -pdflatex="pdflatex -interaction=nonstopmode" main-lba.tex
+
 release: ${BUILD_DIR}.pdf ${BUILD_DIR}-manuscript.pdf ${BUILD_DIR}-supplement.pdf ${BUILD_DIR}.tex
 
 ${BUILD_DIR}.pdf: main.tex
@@ -61,6 +68,7 @@ clean:
 	rm -f ${BUILD_DIR}-manuscript-draft.pdf
 	rm -f ${BUILD_DIR}-supplement.pdf
 	rm -f ${BUILD_DIR}-supplement-draft.pdf
+	rm -f ${BUILD_DIR}-lba.pdf
 
 sview:
 	xdg-open ${BUILD_DIR}-draft.pdf 2>/dev/null
@@ -71,4 +79,4 @@ cleaner: clean
 	find . -type f -name ${BUILD_DIR}"*" ! -name '*.tex' ! -name '*.bib' -delete
 	rm -rf *.bbl *.blg *.aux
 
-.PHONY: draft release clean sview cleaner fresh
+.PHONY: draft release clean sview cleaner fresh lba

--- a/fig/fitness-background-lba.tex
+++ b/fig/fitness-background-lba.tex
@@ -1,0 +1,29 @@
+\begin{figure}
+
+\begin{minipage}{\linewidth}
+\begin{subfigure}[b]{0.692\linewidth}
+\includegraphics[width=\linewidth, trim=0.8cm 0 0 0, clip]{binder-2025-11-30-external-selfbb-truebb.ipynb/binder/teeplots/2025-11-30-external-selfbb-truebb/hue=kind1+style=kind1+viz=lineplot+x=competition-stint+y=focal-prevalence+ext=.pdf}
+\footnotesize
+\vspace{-4.25ex}
+\caption{stints 0 to 100}
+\label{fig:fitness-background:timeseries}
+\end{subfigure}%
+\begin{subfigure}[b]{0.308\linewidth}
+\includegraphics[width=\linewidth, trim=1.3cm 0 0 0.1cm, clip]{binder-2025-11-30-external-selfbb-truebb.ipynb/binder/teeplots/2025-11-30-external-selfbb-truebb/hue=kind+inner=quartile+viz=violinplot+x=kind+y=focal-prevalence+ext=.pdf}
+\footnotesize
+\vspace{-4.25ex}
+\caption{stints 15 to 100}
+\label{fig:fitness-background:distribution}
+\end{subfigure}
+\end{minipage}
+
+\caption{%
+\textbf{Patterned growth creates biogenic niche.}
+\footnotesize
+Around stint 15, fitness of case study strain in self-context diverges significantly above other contexts.
+``None'' background competitions are initialized 50\%/50\% between compared strains; otherwise, competitions are initialized 25\%/25\%/50\% between compared strains and background.
+Shaded bands are bootstrap 95\% CI.
+Mann-Whitney test reported.
+}
+\label{fig:fitness-background}
+\end{figure}

--- a/main-lba.tex
+++ b/main-lba.tex
@@ -1,0 +1,195 @@
+\documentclass[letterpaper]{article}
+\usepackage{authblk}
+
+% Use symbols for footnotes (*, †, ‡, §, etc.) instead of numbers
+% perpage resets the counter on each page to avoid running out of symbols
+\usepackage[symbol,perpage]{footmisc}
+
+\usepackage[footnotes,definitionLists,hashEnumerators,smartEllipses,hybrid]{markdown}
+\usepackage{adjustbox}
+\usepackage[super,comma,sort&compress]{natbib} \usepackage{alifeconf} %% The order is important
+\usepackage[table,xcdraw]{xcolor}
+\usepackage{subcaption}
+\usepackage{longtable}
+\usepackage{listings}
+\usepackage{amsmath}
+\usepackage{hyperref,cleveref}
+\usepackage[moderate]{savetrees}
+\usepackage[parfill]{parskip}
+\usepackage{rotating}
+\usepackage{tabularx}
+\usepackage{rotating}
+\usepackage{pdflscape,lipsum}
+\usepackage{eso-pic,zref-user}
+% \newcounter{cntsideways}
+\usepackage{fancyheadings}
+\usepackage{tikz}
+\usetikzlibrary{calc}
+\usepackage{orcidlink}
+\usepackage{placeins}
+\usepackage{graphbox}
+
+\usepackage{floatpag}
+\floatpagestyle{plain}
+\fancypagestyle{mylandscape}{%
+  \fancyhf{}% Clear header/footer
+  \fancyfoot{% Footer
+  % adapted from https://tex.stackexchange.com/a/9086
+  \tikz[remember picture,overlay]
+        \node[outer sep=0.5in,above,rotate=90] at (current page.east) {\thepage};}  \renewcommand{\headrulewidth}{0pt}% No header rule
+  \renewcommand{\footrulewidth}{0pt}% No footer rule
+}
+
+% adapted from https://tex.stackexchange.com/a/472608
+\usepackage{eso-pic,zref-user}
+\newcounter{cntsideways}
+\makeatletter
+\AddToShipoutPictureBG{%
+  \PLS@RemoveRotate
+}
+\AddToShipoutPictureBG{%
+ \ifnum\zref@extractdefault{rotate\number\value{page}}{page}{0}=0
+  \PLS@RemoveRotate
+ \else
+  \PLS@AddRotate{90}%
+ \fi}
+
+\newcommand\rotatesidewayslabel{\stepcounter{cntsideways}%
+ \zlabel{tmp\thecntsideways}\zlabel{rotate\zref@extractdefault{tmp\thecntsideways}{page}{0}}}
+
+\let\originalsidewaysfigure\sidewaysfigure
+\let\endoriginalsidewaysfigure\endsidewaysfigure
+\renewenvironment{sidewaysfigure}{%
+  \begin{originalsidewaysfigure}%
+  \thisfloatpagestyle{mylandscape}%
+  \rotatesidewayslabel%
+}{%
+  \end{originalsidewaysfigure}%
+}
+
+% \renewenvironment{sidewaysfigure*}{%
+%   \begin{originalsidewaysfigure}%
+%   \thisfloatpagestyle{mylandscape}%
+%   \rotatesidewayslabel%
+% }{%
+%   \end{originalsidewaysfigure}%
+% }
+
+\let\originalsidewaystable\sidewaystable
+\let\endoriginalsidewaystable\endsidewaystable
+\renewenvironment{sidewaystable}{%
+  \begin{originalsidewaystable}%
+  \thisfloatpagestyle{mylandscape}%
+  \rotatesidewayslabel%
+}{%
+  \end{originalsidewaystable}%
+}
+\renewenvironment{sidewaystable*}{%
+  \begin{originalsidewaystable}%
+  \thisfloatpagestyle{mylandscape}%
+  \rotatesidewayslabel%
+}{%
+  \end{originalsidewaystable}%
+}
+
+\let\originallandscape\landscape
+\let\endoriginallandscape\endlandscape
+\renewenvironment{landscape}{%
+  \begin{originallandscape}%
+  \thispagestyle{mylandscape}%
+  \rotatesidewayslabel%
+}{%
+  \end{originallandscape}%
+}
+
+\makeatother
+
+%%% Renew command for full page figures:
+\renewcommand{\topfraction}{1.0}
+
+% Blank page (if needed)
+\newcommand\blankpage{%
+    \null
+    \thispagestyle{empty}%
+    \addtocounter{page}{-1}%
+    \newpage}
+
+
+% pragma once, adapted from https://tex.stackexchange.com/a/195173
+\makeatletter
+\let\pragma@iinput=\@iinput
+\def\@iinput#1{\xdef\@pragmafile{#1}\pragma@iinput{#1}}
+\def\@pragmafile{default}
+\def\pragmaonce{%
+   \csname pragma@\@pragmafile\endcsname
+   \global\expandafter\let \csname pragma@\@pragmafile\endcsname = \endinput
+}
+\makeatother
+
+\ifdefined\mydraft
+\mydraft
+\fi
+
+% \setcounter{tocdepth}{4}
+% \setcounter{secnumdepth}{4}
+
+% *****************
+%  Requirements:
+% *****************
+%
+% - All pages sized consistently at 8.5 x 11 inches (US letter size).
+% - PDF length <= 8 pages for full papers, <=2 pages for extended
+%    abstracts (not including citations).
+% - Abstract length <= 250 words.
+% - No visible crop marks.
+% - Images at no greater than 300 dpi, scaled at 100%.
+% - Embedded open type fonts only.
+% - All layers flattened.
+% - No attachments.
+% - All desired links active in the files.
+
+% Note that the PDF file must not exceed 5 MB if it is to be indexed
+% by Google Scholar. Additional information about Google Scholar
+% can be found here:
+% http://www.google.com/intl/en/scholar/inclusion.html.
+
+
+% If your system does not generate letter format documents by default,
+% you can use the following workflow:
+% latex example
+% bibtex example
+% latex example ; latex example
+% dvips -o example.ps -t letterSize example.dvi
+% ps2pdf example.ps example.pdf
+
+
+% For pdflatex users:
+% The alifeconf style file loads the "graphicx" package, and
+% this may lead some users of pdflatex to experience problems.
+% These can be fixed by editing the alifeconf.sty file to specify:
+% \usepackage[pdftex]{graphicx}
+%   instead of
+% \usepackage{graphicx}.
+% The PDF output generated by pdflatex should match the required
+% specifications and obviously the dvips and ps2pdf steps become
+% unnecessary.
+
+
+% Note:  Some laser printers have a serious problem printing TeX
+% output. The use of ps type I fonts should avoid this problem.
+
+\begin{document}
+
+\input{tex/lba/frontmatter.tex}
+
+\input{tex/abstract.tex}
+
+\input{tex/lba/body.tex}
+
+\input{tex/lba/boilerplate.tex}
+
+\footnotesize
+\bibliographystyle{apalike-ejor}
+\bibliography{bibl} % replace by the name of your .bib file
+
+\end{document}

--- a/tex/lba/body.tex
+++ b/tex/lba/body.tex
@@ -1,0 +1,34 @@
+\section{Introduction}
+
+Complex multicellular organisms exist despite unicellular life growing biomass with substantially greater efficiency \citep{lynch2024bioenergetic}.
+Division-of-labor explanations \citep{Saunders1976,corning2015synergistic,niklas2014evolutionary,Bell1997} recoup only part of this metabolic cost, motivating alternate accounts based on neutral ratcheting of near-neutral redundancies \citep{Gould1988,lynch2003origins,muozgmez2021constructive} or niche construction, whereby feedback from organisms reshapes environmental context in ways that favor complex traits \citep{odlingsmee2003niche,taylor2004niche,laland2014niche}.
+Though implicated in biological multicellularity \citep{niklas2014evolutionary,boraas1998phagotrophy,yoshida2003rapid}, the causal role of \textit{de novo} niche construction in promoting complexity during early multicell evolution remains experimentally untested \citep{goldsby2012task,bozdag2023denovo,ratcliff2012experimental,kalambokidis2023multispecies}.
+
+\section{Experimental System}
+
+\input{fig/overview.tex}
+
+We test this using DISHTINY \citep{moreno2019toward}, a digital model system in which cell-like programs populate a 2D grid, replicating via asexual budding either to grow an existing multicell group or to found a new one (Figure~\ref{fig:overview}).
+Neighboring cells --- within and between groups --- compete for space, share energy, exchange messages, and sense each other's state, creating feedback between evolved phenotypes and environmental context.
+Cell behavior arises from tag-based activation of genome subprograms \citep{lalejini2018evolving,moreno2023matchmaker}.
+Across 40 replicate evolving populations, we assay genotype complexity (genome sites deleterious when knocked out), phenotype complexity (distinct adaptive cell input/output interactions), morphology, and competitive fitness to test whether niche construction promotes and sustains complexity.
+
+\section{Results}
+
+Among replicates, one lineage sustained genotype and phenotype complexity exceeding $3\times$ IQR of all others, alongside a multi-stage patterned life history: an initial elongated ``cigar-like'' morphology (arising at passage 15) followed by an irregular ``box-like'' secondary growth phase (passage 45).
+Tracing this case-study lineage across 100 sequential passages, we identified nine morphologies and repeated abrupt complexity gains coincident with morphological innovation --- e.g., phenotype complexity tripled at the cigar-like transition.
+
+\input{fig/fitness-background-lba.tex}
+
+Competing case-study genomes against a cross-replicate ``measuring stick'' panel, we found that fitness in self-context (i.e., against the lineage's own biogenic background) diverged sharply above fitness in co-evolved or background-free context beginning at this cigar-like transition (Mann-Whitney $p<10^{-25}$, Cliff's $\delta=0.93$; Figure~\ref{fig:fitness-background}) --- the lineage's patterned growth constructed a niche favoring itself over other morphologies.
+
+To test whether this niche construction causally sustains complexity, we conducted evolutionary replay experiments: mutagenizing case-study genomes and reseeding populations under either self- or co-evolved biotic context.
+Replays retaining self context maintained significantly higher genotype complexity than those with co-evolved context (Mann-Whitney $p<0.01$, $\delta=0.25$) --- an effect that vanished under a higher mutagenic dose, confirming that self-acting biotic selection, rather than generic disruption, locks in complexity.
+
+This pattern generalized across replicates: self-adaptation (fitness advantage in self- versus co-evolved context) correlated positively with both genotype and phenotype complexity (Wald tests, $p=0.01$ and $p=5\times10^{-3}$), rivaling or exceeding correlations attributable to adaptation or drift alone.
+
+\section{Discussion}
+
+These findings show that biotic selection arising from an organism's own niche construction can act as a powerful complexity ratchet, complementing --- and potentially reconciling --- adaptationist and neutralist accounts of complexity evolution.
+Because digital multicells reproduce core features of Darwinian evolution while permitting fine-grained causal manipulation \citep{pennock2007models}, this system offers a tractable route to directly test eco-evolutionary feedback hypotheses that are difficult to isolate in biological multicells.
+Ongoing work extends these replay and reciprocal-context designs across longer timescales to assess the generality of ecological complexity lock-in.

--- a/tex/lba/boilerplate.tex
+++ b/tex/lba/boilerplate.tex
@@ -1,0 +1,22 @@
+\section*{Competing Interests}
+
+The authors declare no competing interests.
+
+\section*{Acknowledgements}
+
+Thanks to members of the DEVOLAB, in particular Katherine Perry for help implementing DISHTINY visualizations and Alexander Lalejini for help with SignalGP.
+
+Any opinions, findings, and conclusions or recommendations expressed in this material are those of the author(s) and do not necessarily reflect the views of the National Science Foundation.
+This research was supported in part by NSF grants DEB-2540912, DEB-1655715, DBI-0939454 as well as by Michigan State University through the computational resources provided by the Institute for Cyber-Enabled Research (ICER).
+Thank you to ICER staff, including Nicholas Panchy, for their assistance.
+This material is based upon work supported by the National Science Foundation Graduate Research Fellowship under Grant No. DGE-1424871.
+Any opinions, findings, and conclusions or recommendations expressed in this material are those of the author(s) and do not necessarily reflect the views of the National Science Foundation.
+
+This material is based upon work supported by the Eric and Wendy Schmidt AI in Science Postdoctoral Fellowship, a Schmidt Sciences program.
+M.A.M. completed portions of this work while affiliated with the BEACON Center at Michigan State University.
+
+This material is based upon work supported by the U.S. Department of Energy, Office of Science, Office of Advanced Scientific Computing Research (ASCR), under Award Number DE-SC0025634.
+This report was prepared as an account of work sponsored by an agency of the United States Government.
+Neither the United States Government nor any agency thereof, nor any of their employees, makes any warranty, express or implied, or assumes any legal liability or responsibility for the accuracy, completeness, or usefulness of any information, apparatus, product, or process disclosed, or represents that its use would not infringe privately owned rights.
+Reference herein to any specific commercial product, process, or service by trade name, trademark, manufacturer, or otherwise does not necessarily constitute or imply its endorsement, recommendation, or favoring by the United States Government or any agency thereof.
+The views and opinions of authors expressed herein do not necessarily state or reflect those of the United States Government or any agency thereof.

--- a/tex/lba/frontmatter.tex
+++ b/tex/lba/frontmatter.tex
@@ -1,0 +1,23 @@
+\title{
+    Ecological Origins of Complex Multicellularity:\\Niche Construction Sustains Morphological Innovation
+    \\[1ex]{\normalsize\normalfont\mdseries Late-Breaking Abstract}
+}
+
+\author{
+    Matthew Andres Moreno\orcidlink{0000-0003-4726-4479}$^{1,2,3,4,\dagger}$,\ %
+    Santiago Rodriguez Papa\orcidlink{0000-0002-6028-2105}$^{5,7}$,\ %
+    Luis Zaman\orcidlink{0000-0001-6838-7385}$^{1,2,4}$,\ %
+    Emily Dolson\orcidlink{0000-0001-8616-4898}$^{5,6,7}$,\ %
+    Charles Ofria\orcidlink{0000-0003-2924-1732}$^{5,6,7}$ \\
+    \mbox{}\\
+    $^1$Department of Ecology and Evolutionary Biology
+    $^2$Center for the Study of Complex Systems \\
+    $^3$Michigan Institute for Data and AI in Society
+    $^4$University of Michigan, Ann Arbor, USA \\
+    $^5$Department of Computer Science and Engineering
+    $^6$Program in Ecology, Evolution, and Behavior \\
+    $^7$Michigan State University, East Lansing, USA \\
+    $^\dagger$\texttt{morenoma@umich.edu}
+}
+
+\maketitle


### PR DESCRIPTION
Adds a trimmed two-page late-breaking abstract (main-lba.tex, tex/lba/*)
reusing content from the main manuscript, plus a `make lba` target to
build oee4-lba.pdf.