### PR TITLE
Add binder notebook submodule for eco-gwas-weakstrong analysis

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,9 @@
 	path = tex
 	url = https://github.com/mmore500/oee4.git
 	branch = tex
+
+[submodule "binder-2026-08-13-eco-gwas-weakstrong.ipynb"]
+	path = binder-2026-08-13-eco-gwas-weakstrong.ipynb
+	url = https://github.com/mmore500/oee4.git
+	branch = binder-2026-08-13-eco-gwas-weakstrong.ipynb
+	shallow = true


### PR DESCRIPTION
## Summary
This PR adds a new git submodule pointing to a Jupyter notebook for ecological GWAS weak-strong analysis.

## Changes
- Added new submodule `binder-2026-08-13-eco-gwas-weakstrong.ipynb` that references a specific branch in the oee4 repository
- Configured the submodule with shallow cloning enabled for reduced clone size
- The submodule points to commit `7d6fdafa12900f6364e2a77c0a95cc10939b0144`

## Details
The submodule is configured to track the `binder-2026-08-13-eco-gwas-weakstrong.ipynb` branch with shallow cloning enabled, which helps minimize repository size while maintaining access to the notebook content.

https://claude.ai/code/session_01AZHPQE5shTm8h9TsgWuaxd