### PR TITLE
Rename "stint" to "transfer round" throughout manuscript

### DIFF
--- a/body/conclusion.tex
+++ b/body/conclusion.tex
@@ -15,7 +15,7 @@ We observe instances where novelty coincides with adaptation and instances where
 We observe instances where increases in complexity coincide with adaptation and where decreases in complexity coincide with adaptation.
 We observe instances where innovation coincides with spikes in complexity and instances where it does not.
 We even observe substantial divergences between metrics measuring different aspects of functional complexity.
-For example, the specimen sampled at stint 15 had nearly triple the interface complexity of the specimen sampled at stint 14 but lower critical fitness complexity.
+For example, the specimen sampled at transfer round 15 had nearly triple the interface complexity of the specimen sampled at transfer round 14 but lower critical fitness complexity.
 
 Loose coupling between the conceptual threads of novelty, complexity, and adaptation in this case study highlights the importance of considering these factors independently when developing theory around open-ended evolution --- inherent coupling cannot be assumed.
 

--- a/body/methods.tex
+++ b/body/methods.tex
@@ -17,7 +17,7 @@ Thus, replicates maintained at least two founding strains.
 Among these, we arbitrarily chose one strain for primary study --- the ``focal'' strain;
 another was sampled as the ``background'' (or ``co-evolved'') strain.
 
-For compatibility compute scheduling policy, evolutionary replicates were passaged between fresh simulation runtimes in three hour intervals, which we refer to as ``stints.''
+For compatibility compute scheduling policy, evolutionary replicates were passaged between fresh simulation runtimes in three hour intervals, which we refer to as ``transfer rounds.''
 Each transfer carried over all population genomes, but no other simulation state.
 As a benefit, this protocol ensured strains remained capable of growth from well-mixed inoculum.
 Supplementary Figure \ref{fig:stints} summarizes our serial transfer and diversity maintenance procedures.
@@ -82,7 +82,7 @@ To accelerate the experiment, quadrants of simulation space were distributed acr
 For this reason, phylogeny analyses relied on parsimony-based reconstruction rather than exact tracking \citep{moreno2022hereditary}.
 
 Additional work tested the reproducibility of extreme-complexity outcomes observed in the case study strain, screening 400 additional evolutionary replicates.
-To economize resource usage, these additional replicates used a single 60-hour passaging window (cf. 20 stints).
+To economize resource usage, these additional replicates used a single 60-hour passaging window (cf. 20 transfer rounds).
 % Further technical details appear in supplementary material.
 
 \subsection{Measuring Fitness}
@@ -103,7 +103,7 @@ Therefore, to assess fitness, we rely on competition assays.
 In these competition assays, available space is seeded with an even mix of compared strains.
 Then, after a 10 minute runtime, we evaluate strain abundances (Figure \ref{fig:fit:nobbg}).
 \unskip\footnote{%
-For reference, the case lineage elapses between 8,000 update cycles (stint 0) and 2,000 update cycles (stint 100) during this runtime.
+For reference, the case lineage elapses between 8,000 update cycles (transfer round 0) and 2,000 update cycles (transfer round 100) during this runtime.
 In cases, update-matched competitions were conducted to control for fixed-duration effects.
 Further detail in Supplementary Figures \labelcref{fig:num_updates_elapsed_heatmap,fig:num_updates_elapsed_barplot,fig:num_updates_elapsed_boxplot}.
 }

--- a/body/results.tex
+++ b/body/results.tex
@@ -23,20 +23,20 @@ Then, guided by these findings, we assess how biotic selection shapes evolved co
 
 We qualitatively categorized case study morphologies across each of 100 evolutionary passages,
 % Supplementary Table \ref{tab:morph_descriptions} provides more detailed descriptions of each qualitative morph category, as well as a video and still image example of each.
-% Supplementary Table \ref{tab:morph_by_stint} provides morph categorization for each stint as well as links to view the stint's specimen in a video or in-browser web simulation.
+% Supplementary Table \ref{tab:morph_by_stint} provides morph categorization for each transfer round as well as links to view the transfer round's specimen in a video or in-browser web simulation.
 identifying nine morphologies: labeled ``$b$'' through ``$j$'' (Figure \ref{fig:keyfig:morph}, Supplementary Tables \labelcref{tab:morph_descriptions,tab:morph_by_stint}, and Supplementary Figure \ref{fig:phylo_parsimony_tree}).
 \unskip\footnote{%
 Descriptions of morphs $d$, $h$, $i$, and $f$ --- which were sampled rarely --- appear in supplementary material.
 Morph $a$ was assigned to a separate short-lived lineage.
 }
 
-Early sampled genomes mostly grew as unicells and small groups up to 4 cells (morph $b$), although our earliest sample from the case study lineage formed oversized groups through unchecked cell proliferation (morph $c$, stint 2).
+Early sampled genomes mostly grew as unicells and small groups up to 4 cells (morph $b$), although our earliest sample from the case study lineage formed oversized groups through unchecked cell proliferation (morph $c$, transfer round 2).
 
-The case study lineage's cigar-like patterning first arose at stint 15 (morph $e$).
-% Earlier, at stint 14, we also saw large group formation (morph $d$, irregular clumps of 10 to 15 cells), but the sample's lineage appears to have subsequently gone extinct.
-Subsequently, its secondary phase of box-like vertical growth arose at stint 45 (morph $g$).
-However, around stint 60, cigar-like morph $e$ began to be sampled as a reversion from morph $g$.
-Finally, at stint 100, we first observed morph $j$ (Figure \labelcref{fig:16005-timelapse:update64,fig:16005-timelapse:update256,fig:16005-timelapse:update832,fig:16005-timelapse:update6720,fig:16005-timelapse:update7616}).
+The case study lineage's cigar-like patterning first arose at transfer round 15 (morph $e$).
+% Earlier, at transfer round 14, we also saw large group formation (morph $d$, irregular clumps of 10 to 15 cells), but the sample's lineage appears to have subsequently gone extinct.
+Subsequently, its secondary phase of box-like vertical growth arose at transfer round 45 (morph $g$).
+However, around transfer round 60, cigar-like morph $e$ began to be sampled as a reversion from morph $g$.
+Finally, at transfer round 100, we first observed morph $j$ (Figure \labelcref{fig:16005-timelapse:update64,fig:16005-timelapse:update256,fig:16005-timelapse:update832,fig:16005-timelapse:update6720,fig:16005-timelapse:update7616}).
 This morph presented the two-phase growth pattern of morph $g$, except that some groups also produced cigar-like daughter propagules during the secondary growth phase.
 
 \subsubsection{Complexity}
@@ -44,16 +44,16 @@ This morph presented the two-phase growth pattern of morph $g$, except that some
 After cataloging morphological innovations, we assayed genotype and phenotype complexity across lineage history (Figure \labelcref{fig:keyfig:gcomplexity,fig:keyfig:pcomplexity}, Supplementary Figure \ref{fig:complexity}f).
 
 In several instances, complexity measures increased abruptly with new morphology.
-For instance, at stint 14, morph $d$ (irregular clumps of 10 to 15 cells) coincided with a spike in genotype complexity from 28 to 44 sites.
-At stint 15, cigar-like morph $e$ grew phenotype complexity over threefold from 5 to 17 interactions.
-However, in contrast to these abrupt innovations, genotype complexity grew in a more gradual phase after the rise of cigar-like morph $e$ from 27 to 55 sites between stints 16 and 39.
+For instance, at transfer round 14, morph $d$ (irregular clumps of 10 to 15 cells) coincided with a spike in genotype complexity from 28 to 44 sites.
+At transfer round 15, cigar-like morph $e$ grew phenotype complexity over threefold from 5 to 17 interactions.
+However, in contrast to these abrupt innovations, genotype complexity grew in a more gradual phase after the rise of cigar-like morph $e$ from 27 to 55 sites between transfer rounds 16 and 39.
 
 % In two independent sublineages --- both going extinct --- genotype and phenotype complexity simultaneously and abruptly crashed near zero.
 % Both were morph $i$: unrestricted cell proliferation with small irregular groups.
 % No complexity crash, however, appears in assays configured with biotic background --- suggesting a contingent dependency to this background may have developed (Supplementary Figure \ref{fig:DOTO}).
 
 % https://github.com/mmore500/oee4/blob/binder-2025-11-30-genome-complexity-regression.ipynb/binder/2025-11-30-genome-complexity-regression.ipynb
-Across the case study lineage's history, split regression analysis suggests genotype complexity developed in two distinct regimes (Davies test, $p < 10^{-14}$, adj. $R^2=0.43$): increasing until stint 34 (Wald test, $R^2 = 0.59$, $p < 10^{-6}$), and then decreasing (Wald test, $R^2 = 0.24$, $p < 10^{-4}$) (Supplementary Figure \ref{fig:complexity-cryptic-regression:split}).
+Across the case study lineage's history, split regression analysis suggests genotype complexity developed in two distinct regimes (Davies test, $p < 10^{-14}$, adj. $R^2=0.43$): increasing until transfer round 34 (Wald test, $R^2 = 0.59$, $p < 10^{-6}$), and then decreasing (Wald test, $R^2 = 0.24$, $p < 10^{-4}$) (Supplementary Figure \ref{fig:complexity-cryptic-regression:split}).
 
 In the later period, we found that genotype complexity became harder to detect due to gains in mutational robustness (Supplementary Section \ref{sec:supp-genotype-complexity}).
 Thus, the evolutionary trajectory of genotype complexity appears to be initial growth followed by stabilization.
@@ -63,8 +63,8 @@ Thus, the evolutionary trajectory of genotype complexity appears to be initial g
 Next, we examined fitness changes along the case study lineage.
 For this purpose, we competed samples from successive passages to test for fitness gains at each step.
 Across 100 such assays, 57 sampled genotypes outcompeted their predecessor by a significant margin (Figure \ref{fig:keyfig:morph}, Supplementary Figures \labelcref{fig:median_fitness_differential_symlog,fig:fitness_gain_or_loss}).
-Fitness gains became somewhat more sparse at later time points --- a notable exception, though, being a strong fitness gain from 500-site genome expansion at stint 93.
-% Fitness differentials during the first 40 stints are generally higher magnitude than later fitness differentials, although a strong fitness differential occurs at stint 93 coincident with a genome duplication.
+Fitness gains became somewhat more sparse at later time points --- a notable exception, though, being a strong fitness gain from 500-site genome expansion at transfer round 93.
+% Fitness differentials during the first 40 transfer rounds are generally higher magnitude than later fitness differentials, although a strong fitness differential occurs at transfer round 93 coincident with a genome duplication.
 
 Besides the 57 adaptive steps discussed above, 23 steps were neutral and --- surprisingly --- 20 were deleterious (Figure \ref{fig:keyfig:morph}).
 To assess whether these apparent fitness losses could be explained by within-population variation, we repeated assays to compete whole-population samples rather than monoclonal isolates.
@@ -78,8 +78,8 @@ While drift effects can produce such maladaptation (carrying capacity supported 
 Recall that resource balancing maintained long-term co-existence of an additional independent lineage alongside the case study strain.
 To test whether co-evolutionary interactions with this background strain could account for apparent maladaptations, we repeated fitness competitions to incorporate co-evolved biotic context (see Figure \ref{fig:fit:bbg}).
 % \unskip\footnote{%
-% For this purpose, we used genomes collected from the co-evolved lineage at ``prefatory'' stint $n$, rather than $n + 1$.
-% Results using co-evolved genomes from ``contemporary'' stint $n + 1$ were generally similar, and are included in supplementary material.
+% For this purpose, we used genomes collected from the co-evolved lineage at ``prefatory'' transfer round $n$, rather than $n + 1$.
+% Results using co-evolved genomes from ``contemporary'' transfer round $n + 1$ were generally similar, and are included in supplementary material.
 % }
 
 In co-evolved context, whole-population maladaptations decreased from 16 to 3 (Supplementary Figure \ref{fig:sign-change-prefatory-population}).
@@ -98,18 +98,18 @@ Thus, having found biotic context to exert detectable selection on the case stud
 To characterize the case study lineage's co-evolutionary interactions, we first set out to test if these interactions were mutualistic or antagonistic.
 
 %For this purpose, we needed an absolute (rather than relative) measure of fitness.
-As a proxy for absolute fitness, we assembled a biotic ``measuring stick'' at each stint by drawing comparator samples from each of our 40 independent replicates, providing a fitness measure between 0 (all losses) and 1 (all wins).
+As a proxy for absolute fitness, we assembled a biotic ``measuring stick'' at each transfer round by drawing comparator samples from each of our 40 independent replicates, providing a fitness measure between 0 (all losses) and 1 (all wins).
 
-By this measure, case study lineage fitness was volatile during early evolution, but settled near or below 0.5 from stint 30 onwards (solid line, Figure \ref{fig:fitness-background}) --- meaning it underperformed most other replicates.
+By this measure, case study lineage fitness was volatile during early evolution, but settled near or below 0.5 from transfer round 30 onwards (solid line, Figure \ref{fig:fitness-background}) --- meaning it underperformed most other replicates.
 
 To test how biotic context affected fitness, we repeated these ``measuring stick'' competitions to incorporate the co-evolved lineage as biotic context (dashed line, Figure \ref{fig:fitness-background}).
-Fitness in co-evolved context closely tracked baseline fitness, several transient fitness advantages and a brief fitness penalty at stint 30.
+Fitness in co-evolved context closely tracked baseline fitness, several transient fitness advantages and a brief fitness penalty at transfer round 30.
 
 These results --- in conjunction with reciprocal experiments testing how the case study strain influenced its co-evolved counterpart (Supplementary Figure \ref{fig:external-bb-reciporical}) --- suggest a relationship of transient commensalist interaction, rather than systematic cooperation or antagonism.
 
 For completeness, we additionally tested fitness where the case study lineage served as its own biotic context (dot-dash line, Figure \ref{fig:fitness-background}).
 (In effect, these conditions boost concentration of the case study strain from 50\% to 75\%.)
-Surprisingly, this self-context produced a strong, sustained fitness benefit from stint 15 onward (Mann-Whitney test, $p < 10^{-25}$; Cliff's delta $\delta=0.93$; \ref{fig:fitness-background:distribution}).
+Surprisingly, this self-context produced a strong, sustained fitness benefit from transfer round 15 onward (Mann-Whitney test, $p < 10^{-25}$; Cliff's delta $\delta=0.93$; \ref{fig:fitness-background:distribution}).
 The strength of this effect --- and its origination with cigar-like morph $e$ --- led us to consider an alternate driver of complexity: self-acting biogenic selection arising from the case study strain itself.
 
 \subsection{Case Study Strain Produces Biogenic Selection}
@@ -126,7 +126,7 @@ That is, we performed competitions in the context of case study lineage samples 
 
 Compared to time-shifted context, contemporary self-context provided substantially greater fitness benefit (Mann-Whitney test, $p<10^{-5}$, Cliff's delta $\delta=0.45$; Figure \ref{fig:timeshift}).
 Nonetheless, time-shifted backgrounds still provided some benefit in 78 of 98 tested cases.
-% --- including long temporal offsets of up to 50 stints (Supplementary Figure \ref{fig:timeshift-supp}).
+% --- including long temporal offsets of up to 50 transfer rounds (Supplementary Figure \ref{fig:timeshift-supp}).
 Thus, while the underlying mechanism of niche construction appears to have remained generally stable, traits responsible for exploiting this niche adapted over time to track changes in self-context.
 
 \subsection{Self-acting Selection Maintains Complexity in Case Study Strain}
@@ -141,10 +141,10 @@ This problem is nontrivial, because any amount of the case study strain inherent
 To overcome this challenge, we mutationally attenuated the case study strain when seeding replay trials.
 Mutagenic dose (8 mutations) was chosen such that most, but not all, seeded genomes were substantially disrupted.
 As an additional benefit, applying mutation also enhanced standing variation of seeded populations --- improving sensitivity to detect selection on complexity.
-% providing sufficient sensitivity to allow short 1-stint replays.
+% providing sufficient sensitivity to allow short 1-round replays.
 
 Replays were conducted under both a ``self context'' treatment and a ``co-evolved context'' treatment, seeded with 50\% intact case study lineage genomes or co-evolved genomes (Figure \ref{fig:replay-background:design}).
-To target the complexity maintenance period identified by split regression analysis, replays were conducted from stint 33 onwards --- thus, providing a sample of 67 single-stint replays per treatment.
+To target the complexity maintenance period identified by split regression analysis, replays were conducted from transfer round 33 onwards --- thus, providing a sample of 67 single-round replays per treatment.
 As the endpoint of each replay, we sampled a surviving descendant from mutagenized case study inoculum and measured its complexity.
 
 Across replays, intact self context preserved higher genotype complexity than co-evolved ecological context
@@ -174,7 +174,7 @@ Due to variability in genome sizes, we performed comparison vis-a-vis phenotype 
 Compared to fitness in co-evolved biotic context, fitness in self-dense biotic context exhibited stronger association with complexity (binomial GEE, $p < 0.001$; $p = 0.003$ excluding case study replicate; Figure \ref{fig:general:gee-base}), suggesting niche construction to act broadly in stabilizing evolved multicell complexity.
 
 We also sought to directly test whether high complexity outcomes, such as the case study strain, tend to involve niche construction feedbacks.
-For this purpose, we screened 400 additional 20-stint trials, isolating the 20 most complex (top 5\%) by joint exceedance in genotype- and phenotype-based measures.
+For this purpose, we screened 400 additional 20-round trials, isolating the 20 most complex (top 5\%) by joint exceedance in genotype- and phenotype-based measures.
 Among these high-complexity strains, 90\% were more fit in self-dense contexts, consistent with niche construction effects.
 By contrast, only 56\% of lower-complexity strains exhibited such self-advantage (Fisher's exact test, $p = 0.004$, RR 1.58; Figure \ref{fig:general:pgcomplex-ecoself}).
 

--- a/fig/16005-timelapse.tex
+++ b/fig/16005-timelapse.tex
@@ -70,7 +70,7 @@
 \footnotesize
 Compared to other replicates, case study 16005 sustained extreme outlying complexity (upper panels \labelcref{fig:16005-timelapse:genotype-complexity,fig:16005-timelapse:phenotype-complexity,fig:16005-timelapse:mean-complexity}) and exhibited unique multi-stage patterned growth (lower panels \labelcref{fig:16005-timelapse:update64,fig:16005-timelapse:update256,fig:16005-timelapse:update832,fig:16005-timelapse:update6720,fig:16005-timelapse:update7616}).
 Genotype complexity counts genome sites contributing to fitness; phenotype complexity counts distinct cell input/output operations contributing to fitness --- both determined via knockout/interference trials.
-Snapshots show example life history (morph ``$j$,'' stint 100; Supplementary Table \ref{tab:morph_descriptions}).
+Snapshots show example life history (morph ``$j$,'' transfer round 100; Supplementary Table \ref{tab:morph_descriptions}).
 Hue denotes, and black borders divide, multicell groups; white borders reflect inner structure.
 From initial unicell groups (\ref{fig:16005-timelapse:update64}), cells replicate to form horizontal ``cigar-like'' bodies (\labelcref{fig:16005-timelapse:update256,fig:16005-timelapse:update832}).
 In a delayed second stage of growth, groups expand vertically to produce a ``box-like'' final morphology (\labelcref{fig:16005-timelapse:update6720,fig:16005-timelapse:update7616}).

--- a/fig/ecogwas.tex
+++ b/fig/ecogwas.tex
@@ -25,7 +25,7 @@
 \caption{%
 \textbf{Case study strain selects for genotype complexity in co-evolved partner.}
 \footnotesize
-In stint-100 isolate of case study background strain, 14 genome sites exhibited strong adaptive benefit compared to single-site knockouts when tested with case study strain absent.
+In round-100 isolate of case study background strain, 14 genome sites exhibited strong adaptive benefit compared to single-site knockouts when tested with case study strain absent.
 However, with case study strain present, adaptive benefit was detected at an additional 18 genome sites.
 Co-evolutionary adaptation to case study strain thus accounts for 56\% (18/32) of detected genotype complexity in background strain.
 Supplementary Figure \ref{fig:ecogwas-supp} TODO

--- a/fig/fitness-background.tex
+++ b/fig/fitness-background.tex
@@ -5,14 +5,14 @@
 \includegraphics[width=\linewidth, trim=0.8cm 0 0 0, clip]{../binder/binder-2025-11-30-external-selfbb-truebb.ipynb/binder/teeplots/2025-11-30-external-selfbb-truebb/hue=kind1+style=kind1+viz=lineplot+x=competition-stint+y=focal-prevalence+ext=.pdf}
 \footnotesize
 \vspace{-4.25ex}
-\caption{stints 0 to 100}
+\caption{transfer rounds 0 to 100}
 \label{fig:fitness-background:timeseries}
 \end{subfigure}%
 \begin{subfigure}[b]{0.308\linewidth}
 \includegraphics[width=\linewidth, trim=1.3cm 0 0 0.1cm, clip]{../binder/binder-2025-11-30-external-selfbb-truebb.ipynb/binder/teeplots/2025-11-30-external-selfbb-truebb/hue=kind+inner=quartile+viz=violinplot+x=kind+y=focal-prevalence+ext=.pdf}
 \footnotesize
 \vspace{-4.25ex}
-\caption{stints 15 to 100}
+\caption{transfer rounds 15 to 100}
 \label{fig:fitness-background:distribution}
 \end{subfigure}
 \end{minipage}
@@ -20,7 +20,7 @@
 \caption{%
 \textbf{Patterned growth creates biogenic niche.}
 \footnotesize
-Around stint 15, fitness of case study strain in self-context diverges significantly above other contexts.
+Around transfer round 15, fitness of case study strain in self-context diverges significantly above other contexts.
 For background type ``None,'' competition is initialized 50\%/50\% between compared strains (Figure \ref{fig:fit:nobbg}).
 Otherwise, competition is initialized 25\%/25\%/50\% between compared strains and background (Figure \ref{fig:fit:bbg}).
 Shaded bands are bootstrap 95\% CI.

--- a/fig/replay-background.tex
+++ b/fig/replay-background.tex
@@ -44,11 +44,11 @@ replay trial design
 \caption{%
 \textbf{Constructed niche selects to maintain genotype complexity.}
 \footnotesize
-We performed short one-stint replay trials on the case study strain, in either co-evolved or self context.
+We performed short one-round replay trials on the case study strain, in either co-evolved or self context.
 To enhance standing variation and weaken inherent self-context effects, replay genomes were subject to moderate mutagenesis --- dosed to maintain some functionally intact genomes (\ref{fig:replay-background:design}).
 Replays in self context maintained higher genotype complexity than co-evolved context (Mann-Whitney test, \ref{fig:replay-background:moderatedose}).
 By contrast, more intense mutagenesis did not reproduce this effect, suggesting specificity to preserve already-evolved complexity (Mann-Whitney test, \ref{fig:replay-background:highdose}\protect\footnotemark).
-Supplementary Figure \ref{fig:replay-background-early} shows replay results for stints 0 to 34.
+Supplementary Figure \ref{fig:replay-background-early} shows replay results for transfer rounds 0 to 34.
 }
 \label{fig:replay-background}
 

--- a/fig/timeshift.tex
+++ b/fig/timeshift.tex
@@ -7,7 +7,7 @@
 \caption{%
 \textbf{Adaptive tracking of self-context.}
 \footnotesize
-Fitness benefit from exact self-context (top) exceeds benefit from time-shifted self-context (drawn from stints 33, 40, 50, 66, 75, 90, and 99; Mann-Whitney test).
+Fitness benefit from exact self-context (top) exceeds benefit from time-shifted self-context (drawn from transfer rounds 33, 40, 50, 66, 75, 90, and 99; Mann-Whitney test).
 Supplementary Figure \ref{fig:timeshift-full} further details time-shift analysis.
 }
 \label{fig:timeshift}

--- a/supplement/methods.tex
+++ b/supplement/methods.tex
@@ -62,6 +62,7 @@ Full details on the instruction set and event library used, as well as simulatio
 
 We performed evolution in three-hour windows for compatibility with our compute cluster's scheduling system.
 We refer to these windows as ``stints.''
+\unskip\footnote{In the main text, these windows are referred to as ``transfer rounds'' instead.}
 We randomly generated 100-instruction genomes at the outset of the initial stint, stint 0.
 At the end of each three-hour window, the system harvested and stored genomes in a population file.
 We then seeded subsequent stints with the previous stint's population.


### PR DESCRIPTION
## Summary
This PR updates terminology throughout the manuscript to replace "stint" with "transfer round" as the primary term for the three-hour evolutionary passaging intervals. This change improves clarity and consistency in scientific communication.

## Key Changes
- **Main text (results.tex)**: Replaced all instances of "stint" with "transfer round" in the Results and Conclusion sections, including figure captions and inline references
- **Methods (body/methods.tex)**: Updated the definition of the passaging interval terminology from "stints" to "transfer rounds" in the Evolutionary Replicates subsection
- **Figure captions**: Updated all figure references and captions (fitness-background.tex, replay-background.tex, 16005-timelapse.tex, ecogwas.tex, timeshift.tex) to use "transfer round" terminology
- **Supplementary methods (supplement/methods.tex)**: Added a footnote clarifying that supplementary material uses "stint" while main text uses "transfer round" for the same concept

## Notable Details
- The change is comprehensive across all document sections while maintaining consistency
- A clarifying footnote was added to the supplementary methods to explain the terminology difference between main and supplementary text
- All numerical references (e.g., "stint 15", "stint 100") were converted to "transfer round 15", "transfer round 100" format
- The underlying scientific content and data remain unchanged; this is purely a terminology update for improved readability

https://claude.ai/code/session_01UgFV7JHFLpPs2Ro8wcq2zA