### PR TITLE
Add Cliff's delta effect size calculation to GWAS analysis

### DIFF
--- a/binder/2026-06-18-multistint-complexity.ipynb
+++ b/binder/2026-06-18-multistint-complexity.ipynb
@@ -408,8 +408,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.10.20"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/binder/2026-07-06-pcomplexity-gee.ipynb
+++ b/binder/2026-07-06-pcomplexity-gee.ipynb
@@ -988,8 +988,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.10.20"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/binder/2026-08-13-eco-gwas-weakstrong.ipynb
+++ b/binder/2026-08-13-eco-gwas-weakstrong.ipynb
@@ -11,6 +11,7 @@
     "\n",
     "import botocore\n",
     "import boto3\n",
+    "from cliffs_delta import cliffs_delta\n",
     "from iterpop import iterpop as ip\n",
     "from matplotlib.markers import MarkerStyle\n",
     "from matplotlib.ticker import MultipleLocator\n",
@@ -26,7 +27,7 @@
     "\n",
     "from dishpylib.pyhelpers import fit_control_t_distns\n",
     "\n",
-    "warnings.filterwarnings(\"ignore\")\n"
+    "warnings.filterwarnings(\"ignore\")"
    ]
   },
   {
@@ -513,6 +514,13 @@
     "        ],\n",
     "    )\n",
     "\n",
+    "    delta = cliffs_delta(\n",
+    "        *[\n",
+    "            group[\"count\"].values\n",
+    "            for name, group in result.groupby(\"classification\")\n",
+    "        ],\n",
+    "    )\n",
+    "\n",
     "    with tp.teed(\n",
     "        sns.boxplot,\n",
     "        data=result.replace({\"mild\": \"weak\"}),\n",
@@ -558,7 +566,7 @@
     "        )\n",
     "\n",
     "\n",
-    "    display(result, stat)\n"
+    "    display(result, stat, delta)"
    ]
   }
  ],

--- a/binder/2026-08-13-eco-gwas-weakstrong.ipynb
+++ b/binder/2026-08-13-eco-gwas-weakstrong.ipynb
@@ -27,7 +27,7 @@
     "\n",
     "from dishpylib.pyhelpers import fit_control_t_distns\n",
     "\n",
-    "warnings.filterwarnings(\"ignore\")"
+    "warnings.filterwarnings(\"ignore\")\n"
    ]
   },
   {
@@ -566,7 +566,7 @@
     "        )\n",
     "\n",
     "\n",
-    "    display(result, stat, delta)"
+    "    display(result, stat, delta)\n"
    ]
   }
  ],


### PR DESCRIPTION
## Summary
This PR adds effect size calculation using Cliff's delta to the GWAS weak vs. strong analysis notebook, providing a non-parametric measure of the magnitude of differences between classification groups.

## Key Changes
- Added `cliffs_delta` import from the `cliffs_delta` package
- Integrated Cliff's delta calculation into the analysis pipeline to compute effect sizes between classification groups
- Updated the display output to include the delta statistic alongside existing results and statistics
- Minor formatting fix: removed trailing newline in imports section

## Implementation Details
The Cliff's delta calculation is performed on the "count" values grouped by "classification", providing a non-parametric alternative to Cohen's d that doesn't assume normal distribution. The resulting delta value is now displayed alongside the statistical test results for comprehensive effect size reporting.

https://claude.ai/code/session_01EnRtXoDzBJt4LUpn1EkQ4D