### PR TITLE
Harden fig/complexity.tex subcaption spacing

### DIFF
--- a/fig/complexity.tex
+++ b/fig/complexity.tex
@@ -1,45 +1,27 @@
 \begin{figure*}
-
 \centering
+\captionsetup[subfigure]{font=footnotesize,skip=0pt}
 
 \begin{subfigure}{0.31\linewidth}
-\includegraphics[width=\linewidth, clip, trim={0 0 1.6cm 0}]{../binder/binder-2025-08-26-dotfig/binder/teeplots/2025-08-26-dotfig/bucket=prq49+cat=morph+endeavor=16+transform=filter-Series-16005+viz=letterscatter+x=stint+y=num-instructions+ext=.pdf}
-\end{subfigure}
-~
-\begin{subfigure}{0.29\linewidth}
-\includegraphics[width=\linewidth, clip, trim={0 0 1.6cm 0}]{../binder/binder-2025-08-26-dotfig/binder/teeplots/2025-08-26-dotfig/bucket=prq49+cat=morph+endeavor=16+transform=filter-Series-16005+viz=letterscatter+x=stint+y=critical-fitness-complexity+ext=.pdf}
-\end{subfigure}
-~
-\begin{subfigure}{0.35\linewidth}
-\includegraphics[width=\linewidth, clip, trim={0 0 0 0}]{../binder/binder-2025-08-26-dotfig/binder/teeplots/2025-08-26-dotfig/bucket=prq49+cat=morph+endeavor=16+transform=filter-Series-16005+viz=letterscatter+x=stint+y=cardinal-interface-complexity+ext=.pdf}
-\end{subfigure}%
-
-\begin{minipage}{\linewidth}
 \centering
-\begin{minipage}[t]{0.31\linewidth}
-\vspace{-2ex}
-\subcaption{\footnotesize
-genome size
-}
+\includegraphics[width=\linewidth, clip, trim={0 0 1.6cm 0}]{../binder/binder-2025-08-26-dotfig/binder/teeplots/2025-08-26-dotfig/bucket=prq49+cat=morph+endeavor=16+transform=filter-Series-16005+viz=letterscatter+x=stint+y=num-instructions+ext=.pdf}
+\caption{genome size}
 \label{fig:complexity:size}
-\end{minipage}
-~
-\begin{minipage}[t]{0.29\linewidth}
-\vspace{-2ex}
-\subcaption{\footnotesize
-genotype complexity
-}
+\end{subfigure}
+\hfill
+\begin{subfigure}{0.29\linewidth}
+\centering
+\includegraphics[width=\linewidth, clip, trim={0 0 1.6cm 0}]{../binder/binder-2025-08-26-dotfig/binder/teeplots/2025-08-26-dotfig/bucket=prq49+cat=morph+endeavor=16+transform=filter-Series-16005+viz=letterscatter+x=stint+y=critical-fitness-complexity+ext=.pdf}
+\caption{genotype complexity}
 \label{fig:complexity:genetic}
-\end{minipage}
-~
-\begin{minipage}[t]{0.35\linewidth}
-\vspace{-2ex}
-\subcaption{\footnotesize
-phenotype complexity
-}
+\end{subfigure}
+\hfill
+\begin{subfigure}{0.35\linewidth}
+\centering
+\includegraphics[width=\linewidth, clip, trim={0 0 0 0}]{../binder/binder-2025-08-26-dotfig/binder/teeplots/2025-08-26-dotfig/bucket=prq49+cat=morph+endeavor=16+transform=filter-Series-16005+viz=letterscatter+x=stint+y=cardinal-interface-complexity+ext=.pdf}
+\caption{phenotype complexity}
 \label{fig:complexity:phenotypic}
-\end{minipage}
-\end{minipage}
+\end{subfigure}
 
 \caption{%
 \textbf{Genome content and complexity.}

--- a/fig/ecogwas.tex
+++ b/fig/ecogwas.tex
@@ -1,10 +1,11 @@
 \begin{figure}
 \centering
+\captionsetup[subfigure]{font=footnotesize,skip=0pt}
 
 \begin{subfigure}{\linewidth}
 \centering
 \includegraphics[height=0.9\linewidth,angle=90]{../binder/binder-2026-06-22-eco-gwas.ipynb/binder/teeplots/viz=subplots+ext=.pdf}
-\caption{\footnotesize case study strain drives genetic adaptations in its co-evolved partner}
+\caption{case study strain drives genetic adaptations in its co-evolved partner}
 \label{fig:ecogwas:sites}
 \end{subfigure}
 
@@ -14,7 +15,7 @@
 \centering
 \includegraphics[height=0.33\linewidth]{../binder/binder-2026-08-13-eco-gwas-weakstrong.ipynb/binder/teeplots/2026-08-13-eco-gwas-weakstrong/col=classification+hue=classification+style=classification+viz=relplot+x=focal-prevalence-backgroundbb+y=focal-prevalence-focalbb+ythresh=0.45+ext=.pdf}%
 \includegraphics[height=0.33\linewidth]{../binder/binder-2026-08-13-eco-gwas-weakstrong.ipynb/binder/teeplots/2026-08-13-eco-gwas-weakstrong/color=white+viz=boxplot+x=classification+y=count+ythresh=0.45+ext=.pdf}
-\caption{\footnotesize strains adapted to co-evo context show more added genetic complexity}
+\caption{strains adapted to co-evo context show more added genetic complexity}
 \label{fig:ecogwas:ythresh045}
 \end{subfigure}
 


### PR DESCRIPTION
## Summary

- `fig/complexity.tex` used a `minipage`-based subcaption layout (images in one row, captions in a separate `minipage` row, each pulled up with `\vspace{-2ex}`) — the same fragile pattern as the Figure 7 / `general-supp.tex` bugs fixed in #90, just implemented with raw `minipage`/`\subcaption` instead of `subfigure`.
- Rebuilt this figure in the actual CI Docker image (`ghcr.io/mmore500/teximage:sha-77b8179`) against the real chart PDFs and didn't find it currently broken — but since it's the identical fragile construct, hardened it the same way as #90 for consistency: caption directly under its own graphic inside a standard `subfigure`, with `\captionsetup[subfigure]{font=footnotesize,skip=0pt}` driving formatting instead of ad hoc `\vspace`/`\subcaption`.
- No visual change — rebuilt before/after in the real CI image and the layout is identical, just without the fragile magic-constant construct.

## Test plan

- [x] Rebuilt inside `ghcr.io/mmore500/teximage:sha-77b8179` against the real chart PDFs (via the `paper` branch's `binder/binder-2025-08-26-dotfig` submodule) — compiles cleanly.
- [x] Visually confirmed layout is unchanged before/after.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_019fzmkfhYVrRTE3gQFp1GNn

---
_Generated by [Claude Code](https://claude.ai/code/session_019fzmkfhYVrRTE3gQFp1GNn)_